### PR TITLE
Add the set of PIXEL_*_EXPERIENCE features for sunfish

### DIFF
--- a/device-sunfish.mk
+++ b/device-sunfish.mk
@@ -116,3 +116,7 @@ PRODUCT_PRODUCT_PROPERTIES += ro.com.google.ime.height_ratio=1.2
 # Bluetooth Tx power caps for sunfish
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/bluetooth_power_limits_sunfish.csv:$(TARGET_COPY_OUT_VENDOR)/etc/bluetooth_power_limits.csv
+
+# Set of *_EXPERIENCE features for sunfish
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/google_experience.xml:$(TARGET_COPY_OUT_PRODUCT)/etc/sysconfig/google_experience.xml

--- a/google_experience.xml
+++ b/google_experience.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<config>
+    <feature name="com.google.android.feature.GOOGLE_EXPERIENCE" />
+    <feature name="com.google.android.feature.PIXEL_EXPERIENCE" />
+    <feature name="com.google.android.feature.PIXEL_2017_EXPERIENCE" />
+    <feature name="com.google.android.feature.PIXEL_2018_EXPERIENCE" />
+    <feature name="com.google.android.feature.PIXEL_2019_MIDYEAR_EXPERIENCE" />
+    <feature name="com.google.android.feature.PIXEL_2019_EXPERIENCE" />
+    <feature name="com.google.android.feature.PIXEL_2020_MIDYEAR_EXPERIENCE" />
+</config>


### PR DESCRIPTION
Add the set of features that apps might use to identify Pixel devices. The features containing years are described by Google as "This is meant to be the canonical feature identifying YEAR and newer Pixel devices." 
(See https://github.com/GrapheneOS/os-issue-tracker/issues/572 for context)