### PR TITLE
Revert "Use inline carrier extraction"

### DIFF
--- a/device-common.mk
+++ b/device-common.mk
@@ -148,7 +148,3 @@ PRODUCT_PACKAGES += \
 # sysconfig XML from stock
 PRODUCT_COPY_FILES += \
 	$(LOCAL_PATH)/product-sysconfig-stock.xml:$(TARGET_COPY_OUT_PRODUCT)/etc/sysconfig/product-sysconfig-stock.xml
-
-PRODUCT_PACKAGES += \
-    extracted-carrierconfig \
-    extracted-apns

--- a/device.mk
+++ b/device.mk
@@ -38,8 +38,7 @@ PRODUCT_SOONG_NAMESPACES += \
     vendor/google/interfaces \
     vendor/google_devices/common/proprietary/confirmatioui_hal \
     vendor/google_nos/host/android \
-    vendor/google_nos/test/system-test-harness \
-    vendor/carriersettings-extractor
+    vendor/google_nos/test/system-test-harness
 
 # Include sensors soong namespace
 PRODUCT_SOONG_NAMESPACES += \


### PR DESCRIPTION
This reverts commit 7815cb618ef07e6caf30501407a3f7903980cf8e.